### PR TITLE
README: expand deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # PySyntax [![Travis-CI Build Status](https://travis-ci.org/kdheepak/PySyntax.jl.svg?branch=master)](https://travis-ci.org/kdheepak/PySyntax.jl) [![AppVeyor](https://img.shields.io/appveyor/ci/gruntjs/grunt.svg)](https://ci.appveyor.com/project/kdheepak/pysyntax-jl)
 
-** This package is deprecated [JuliaLang/julia/issues/1974](https://github.com/JuliaLang/julia/issues/1974) has been merged and this dot-overloading functionality has since been implemented in PyCall.jl with https://github.com/JuliaPy/PyCall.jl/commit/e4035b83148b296ddef0804177a970cf826dcd8d **
+**This package is deprecated:**
+- [JuliaLang/julia#1974](https://github.com/JuliaLang/julia#1974) ("allow overloading of a.b field access syntax") has been fixed with the merging of [JuliaLang/julia#24960](https://github.com/JuliaLang/julia/pull/24960);
+- The dot-overloading functionality it enabled has since been implemented in PyCall.jl, with the merge of [JuliaPy/PyCall.jl#517](https://github.com/JuliaPy/PyCall.jl/pull/517).
 
-Python-like syntax in [Julia](https://github.com/JuliaLang/julia). PySyntax.jl provides a light wrapper on top of [PyCall.jl](https://github.com/JuliaPy/PyCall.jl) in the form of a macro.
+----
+
+PySyntax.jl enables using Python-like syntax in [Julia](https://github.com/JuliaLang/julia).
+It provides a light wrapper on top of [PyCall.jl](https://github.com/JuliaPy/PyCall.jl), in the form of a macro.
 
 ![](./img/screenshot.png)
 


### PR DESCRIPTION
Just to improve readability and add more context.

Note that the previous markdown syntax was not interpreted as bold by GitHub.

(Follow-up of #1.)